### PR TITLE
Upgrade Stuck Detector: server-driven auto-hint with race-condition s…

### DIFF
--- a/Back/src/controllers/stageController.js
+++ b/Back/src/controllers/stageController.js
@@ -3,8 +3,16 @@ const Stage = require("../models/Stage");
 const Challenge = require("../models/Challenge");
 const UserStageProgress = require("../models/UserStageProgress");
 const { runChallengeCode } = require("../utils/runChallengeCode");
-const { fetchSonarStub, fetchAiFeedback } = require("../utils/stageAnalysis");
+const { fetchSonarStub, fetchAiFeedback, fetchExerciseHelp } = require("../utils/stageAnalysis");
 const gamificationService = require("../services/gamificationService");
+const { generateChallenges } = require("../services/aiStageGenerator");
+const { httpStatusForAiError } = require("../services/aiExerciseService");
+const { generateFallbackStageExercises } = require("../utils/fallbackStageExercises");
+const {
+  replaceStageChallenges,
+  detachChallengeFromStage,
+  clearStageIdForDeletedStage,
+} = require("../utils/stageChallengeSync");
 
 function toUserId(req) {
   return new mongoose.Types.ObjectId(String(req.user.id));
@@ -54,13 +62,84 @@ function recomputeProgressFields(progressDoc, stage) {
 exports.adminListStages = async (req, res) => {
   try {
     const stages = await Stage.find()
-      .sort({ category: 1, order: 1 })
+      .sort({ category: 1, level: 1, order: 1 })
       .populate("challenges", "title difficulty language")
       .populate("prerequisiteStageId", "title order");
     res.json(stages);
   } catch (err) {
     console.error(err);
+    if (err.code && String(err.code).startsWith("AI_")) {
+      return res.status(httpStatusForAiError(err)).json({
+        message: err.message,
+        code: err.code,
+        detail: err.detail || err.cause?.message,
+        helpUrl: err.helpUrl,
+      });
+    }
     res.status(500).json({ message: "Server error", detail: err.message });
+  }
+};
+
+/** Participant: request help (hint/explain/course) for a challenge */
+exports.getChallengeHelp = async (req, res) => {
+  try {
+    const { id: stageId, challengeId } = req.params;
+    const userId = toUserId(req);
+    const type = String(req.body?.type || "hint").trim().toLowerCase();
+
+    const HELP_COSTS = { hint: 5, explain: 10, course: 15 };
+    const xpCost = HELP_COSTS[type] ?? HELP_COSTS.hint;
+
+    const stage = await Stage.findById(stageId).populate("challenges");
+    if (!stage) return res.status(404).json({ message: "Stage not found" });
+
+    const access = await assertParticipantCanAccessStage(userId, stage);
+    if (!access.ok) {
+      return res.status(403).json({
+        message: "Stage locked",
+        prerequisiteTitle: access.prerequisiteTitle,
+      });
+    }
+
+    const challenge = (stage.challenges || []).find((c) => String(c?._id) === String(challengeId));
+    if (!challenge) {
+      return res.status(404).json({ message: "Challenge not found on this stage" });
+    }
+
+    let xp = null;
+    try {
+      xp = await gamificationService.spendXP(userId, xpCost);
+    } catch (e) {
+      if (e?.code === "INSUFFICIENT_XP") {
+        return res.status(400).json({
+          message: "Not enough XP",
+          code: "INSUFFICIENT_XP",
+          required: e.required,
+          current: e.current,
+        });
+      }
+      throw e;
+    }
+
+    const help = await fetchExerciseHelp({
+      type,
+      stageTitle: stage.title,
+      challengeTitle: challenge.title,
+      challengeDescription: challenge.description,
+      language: challenge.language,
+      starterCode: challenge.starterCode,
+      code: req.body?.code,
+    });
+
+    return res.json({
+      message: "Help generated",
+      help,
+      xp,
+      xpCost,
+    });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: "Server error", detail: err.message });
   }
 };
 
@@ -71,32 +150,86 @@ exports.createStage = async (req, res) => {
       title,
       description,
       difficulty,
+      level,
       order,
       category,
       prerequisiteStageId,
       challenges,
+      language = "javascript",
+      count = 5,
+      generateWithAi = false,
     } = req.body;
 
-    if (!title || order === undefined) {
-      return res.status(400).json({ message: "title and order are required" });
+    const normalizedLevel = Number(level ?? order);
+    if (!title || !Number.isFinite(normalizedLevel) || normalizedLevel < 1) {
+      return res.status(400).json({ message: "title and level (or order) are required" });
+    }
+
+    let prerequisite = null;
+    if (prerequisiteStageId) {
+      prerequisite = await Stage.findById(prerequisiteStageId).select("_id");
+      if (!prerequisite) {
+        return res.status(404).json({ message: "Prerequisite stage not found" });
+      }
     }
 
     const stage = new Stage({
       title,
       description: description || "",
       difficulty: difficulty || "easy",
-      order: Number(order),
+      level: normalizedLevel,
+      order: normalizedLevel,
       category: category || "training",
-      prerequisiteStageId: prerequisiteStageId || null,
-      challenges: Array.isArray(challenges) ? challenges : [],
+      prerequisiteStageId: prerequisite?._id || null,
+      challenges: [],
     });
     await stage.save();
+
+    if (Array.isArray(challenges) && challenges.length) await replaceStageChallenges(stage._id, challenges);
+
+    // AI generation is explicit (separate action in Admin UI), never forced by default.
+    if (generateWithAi) {
+      try {
+        const generated = await generateChallenges({
+          topic: title,
+          difficulty: difficulty || "easy",
+          language,
+          count: Number(count),
+        });
+
+        for (const g of generated) {
+          const ch = new Challenge({
+            title: g.title,
+            description: g.description || "",
+            difficulty: g.difficulty || difficulty || "easy",
+            type: "Stage",
+            stageId: stage._id,
+            language: g.language || language,
+            starterCode: g.starterCode || "",
+            testCases: Array.isArray(g.testCases) ? g.testCases : [],
+            category: g.category || "general",
+            constraints: g.constraints || "",
+            xpReward: g.xpReward ?? (difficulty === "easy" ? 50 : difficulty === "medium" ? 100 : 200),
+          });
+          await ch.save();
+          stage.challenges.push(ch._id);
+        }
+        await stage.save();
+      } catch (aiErr) {
+        console.error("AI generation failed (stage still created):", aiErr.message);
+      }
+    }
+
     const populated = await Stage.findById(stage._id)
       .populate("challenges")
       .populate("prerequisiteStageId", "title order");
     res.status(201).json(populated);
   } catch (err) {
     console.error(err);
+    if (["NOT_FOUND", "BAD_IDS", "DUPLICATE_IDS", "BATTLE_NOT_ALLOWED"].includes(err.code)) {
+      const status = err.code === "NOT_FOUND" ? 404 : 400;
+      return res.status(status).json({ message: err.message, code: err.code });
+    }
     res.status(500).json({ message: "Server error", detail: err.message });
   }
 };
@@ -106,16 +239,44 @@ exports.updateStage = async (req, res) => {
   try {
     const { id } = req.params;
     const updates = { ...req.body };
-    if (updates.order !== undefined) updates.order = Number(updates.order);
+    const hasChallengesUpdate = Object.prototype.hasOwnProperty.call(updates, "challenges");
+    const challengeIds = hasChallengesUpdate ? updates.challenges : null;
+    const hasLevel = updates.level !== undefined;
+    const hasOrder = updates.order !== undefined;
+    if (hasLevel || hasOrder) {
+      const normalizedLevel = Number(hasLevel ? updates.level : updates.order);
+      if (!Number.isFinite(normalizedLevel) || normalizedLevel < 1) {
+        return res.status(400).json({ message: "level/order must be a number greater than 0" });
+      }
+      updates.level = normalizedLevel;
+      updates.order = normalizedLevel;
+    }
+    if (hasChallengesUpdate) delete updates.challenges;
     delete updates._id;
 
     const stage = await Stage.findByIdAndUpdate(id, { $set: updates }, { new: true })
       .populate("challenges")
       .populate("prerequisiteStageId", "title order");
     if (!stage) return res.status(404).json({ message: "Stage not found" });
+
+    if (hasChallengesUpdate) {
+      if (!Array.isArray(challengeIds)) {
+        return res.status(400).json({ message: "challenges must be an array of IDs" });
+      }
+      const synced = await replaceStageChallenges(id, challengeIds);
+      const populated = await Stage.findById(synced._id)
+        .populate("challenges")
+        .populate("prerequisiteStageId", "title order");
+      return res.json(populated);
+    }
+
     res.json(stage);
   } catch (err) {
     console.error(err);
+    if (["NOT_FOUND", "BAD_IDS", "DUPLICATE_IDS", "BATTLE_NOT_ALLOWED"].includes(err.code)) {
+      const status = err.code === "NOT_FOUND" ? 404 : 400;
+      return res.status(status).json({ message: err.message, code: err.code });
+    }
     res.status(500).json({ message: "Server error", detail: err.message });
   }
 };
@@ -126,6 +287,7 @@ exports.deleteStage = async (req, res) => {
     const { id } = req.params;
     const stage = await Stage.findByIdAndDelete(id);
     if (!stage) return res.status(404).json({ message: "Stage not found" });
+    await clearStageIdForDeletedStage(id);
     await UserStageProgress.deleteMany({ stageId: id });
     await Stage.updateMany({ prerequisiteStageId: id }, { $set: { prerequisiteStageId: null } });
     res.json({ message: "Stage deleted" });
@@ -143,22 +305,12 @@ exports.assignChallengesToStage = async (req, res) => {
     if (!Array.isArray(challengeIds)) {
       return res.status(400).json({ message: "challengeIds array required" });
     }
-    const stage = await Stage.findById(id);
-    if (!stage) return res.status(404).json({ message: "Stage not found" });
-
-    const ids = challengeIds.map((c) => new mongoose.Types.ObjectId(String(c)));
-    const count = await Challenge.countDocuments({ _id: { $in: ids } });
-    if (count !== ids.length) {
-      return res.status(400).json({ message: "One or more challenge IDs are invalid" });
-    }
-
-    stage.challenges = ids;
-    await stage.save();
+    const stage = await replaceStageChallenges(id, challengeIds);
 
     const progresses = await UserStageProgress.find({ stageId: id });
     for (const p of progresses) {
       p.completedChallenges = p.completedChallenges.filter((cid) =>
-        ids.some((i) => i.equals(cid))
+        stage.challenges.some((i) => i.equals(cid))
       );
       recomputeProgressFields(p, stage);
       await p.save();
@@ -168,6 +320,10 @@ exports.assignChallengesToStage = async (req, res) => {
     res.json(populated);
   } catch (err) {
     console.error(err);
+    if (err.code === "NOT_FOUND") return res.status(404).json({ message: err.message, code: err.code });
+    if (["BAD_IDS", "DUPLICATE_IDS", "BATTLE_NOT_ALLOWED"].includes(err.code)) {
+      return res.status(400).json({ message: err.message, code: err.code });
+    }
     res.status(500).json({ message: "Server error", detail: err.message });
   }
 };
@@ -179,6 +335,7 @@ exports.removeChallengeFromStage = async (req, res) => {
     const stage = await Stage.findById(id);
     if (!stage) return res.status(404).json({ message: "Stage not found" });
     const cid = new mongoose.Types.ObjectId(String(challengeId));
+    await detachChallengeFromStage(id, challengeId);
     stage.challenges = stage.challenges.filter((c) => !c.equals(cid));
     await stage.save();
 
@@ -209,7 +366,7 @@ exports.getMyStages = async (req, res) => {
     if (category) query.category = category;
 
     const stages = await Stage.find(query)
-      .sort({ order: 1 })
+      .sort({ level: 1, order: 1 })
       .populate("prerequisiteStageId", "title order")
       .populate("challenges", "title difficulty language");
 
@@ -403,19 +560,95 @@ exports.submitChallenge = async (req, res) => {
       fetchAiFeedback(code, challenge.title),
     ]);
 
-    if (!run.passed) {
-      return res.status(400).json({
-        message: "Tests did not pass",
-        testResults: run.testResults,
-        executionTimeMs: run.executionTimeMs,
-        sonar,
-        aiFeedback,
-      });
-    }
-
     let progress = await UserStageProgress.findOne({ userId, stageId });
     if (!progress) {
       progress = new UserStageProgress({ userId, stageId, completedChallenges: [], status: "available" });
+    }
+
+    if (!progress.failedAttemptsByChallenge) {
+      progress.failedAttemptsByChallenge = new Map();
+    }
+    if (!progress.lastCodeByChallenge) {
+      progress.lastCodeByChallenge = new Map();
+    }
+
+    const failKey = String(challenge._id);
+    const currentFails = Number(progress.failedAttemptsByChallenge.get(failKey) || 0);
+    const lastCode = progress.lastCodeByChallenge.get(failKey) || "";
+    const currentCode = String(code || "").trim();
+
+    // Check if code is meaningful (non-empty, not just whitespace)
+    const isMeaningfulCode = currentCode.length > 0;
+
+    // Check for duplicate submission to prevent spam
+    const isDuplicate = currentCode === lastCode;
+
+    if (!run.passed) {
+      // Only increment if code is meaningful and not a duplicate
+      if (isMeaningfulCode && !isDuplicate) {
+        const nextFails = currentFails + 1;
+        progress.failedAttemptsByChallenge.set(failKey, nextFails);
+        progress.lastCodeByChallenge.set(failKey, currentCode);
+        await progress.save();
+
+        // Calculate stuckLevel: 0=normal, 1=warning (3 fails), 2=struggling (5 fails), 3=critical (6+ fails)
+        let stuckLevel = 0;
+        if (nextFails >= 6) stuckLevel = 3;
+        else if (nextFails >= 5) stuckLevel = 2;
+        else if (nextFails >= 3) stuckLevel = 1;
+
+        // Backend decides if auto hint should trigger (stuckLevel >= 2 and meaningful code)
+        const autoHintTrigger = stuckLevel >= 2;
+        const submissionId = `${challengeId}-${Date.now()}`;
+
+        console.log("[STUCK DETECTOR] Failed submission - userId:", userId, "challengeId:", challengeId, "fails:", nextFails, "stuckLevel:", stuckLevel, "autoHintTrigger:", autoHintTrigger, "submissionId:", submissionId);
+
+        return res.status(400).json({
+          message: "Tests did not pass",
+          testResults: run.testResults,
+          executionTimeMs: run.executionTimeMs,
+          sonar,
+          aiFeedback,
+          isStuck: nextFails >= 3,
+          failedSubmissionsInRow: nextFails,
+          stuckLevel,
+          autoHintTrigger,
+          submissionId,
+        });
+      } else {
+        // Don't increment for empty or duplicate submissions
+        const nextFails = currentFails;
+        let stuckLevel = 0;
+        if (nextFails >= 6) stuckLevel = 3;
+        else if (nextFails >= 5) stuckLevel = 2;
+        else if (nextFails >= 3) stuckLevel = 1;
+
+        // Backend decides if auto hint should trigger (stuckLevel >= 2 and meaningful code)
+        const autoHintTrigger = stuckLevel >= 2;
+        const submissionId = `${challengeId}-${Date.now()}`;
+
+        console.log("[STUCK DETECTOR] Failed submission (no increment) - userId:", userId, "challengeId:", challengeId, "fails:", nextFails, "stuckLevel:", stuckLevel, "autoHintTrigger:", autoHintTrigger, "isDuplicate:", isDuplicate, "isMeaningfulCode:", isMeaningfulCode, "submissionId:", submissionId);
+
+        return res.status(400).json({
+          message: "Tests did not pass",
+          testResults: run.testResults,
+          executionTimeMs: run.executionTimeMs,
+          sonar,
+          aiFeedback,
+          isStuck: nextFails >= 3,
+          failedSubmissionsInRow: nextFails,
+          stuckLevel,
+          autoHintTrigger,
+          isDuplicate,
+          isMeaningfulCode,
+          submissionId,
+        });
+      }
+    }
+
+    // Passed: reset failure counter for this challenge.
+    if (currentFails > 0) {
+      progress.failedAttemptsByChallenge.set(failKey, 0);
     }
 
     const cidStr = challenge._id.toString();
@@ -449,6 +682,16 @@ exports.submitChallenge = async (req, res) => {
       nextStageUnlocked = next.length > 0;
     }
 
+    // Passed: reset failure counter and last code for this challenge.
+    if (currentFails > 0) {
+      progress.failedAttemptsByChallenge.set(failKey, 0);
+      progress.lastCodeByChallenge.set(failKey, currentCode);
+    }
+
+    console.log("[STUCK DETECTOR] Success submission - userId:", userId, "challengeId:", challengeId, "stuckLevel: 0", "autoHintTrigger: false");
+
+    const submissionId = `${challengeId}-${Date.now()}`;
+
     res.json({
       message: "Submission accepted",
       testResults: run.testResults,
@@ -456,13 +699,17 @@ exports.submitChallenge = async (req, res) => {
       output: run.outputSnapshot,
       sonar,
       aiFeedback,
+      isStuck: false,
+      failedSubmissionsInRow: 0,
+      stuckLevel: 0,
+      autoHintTrigger: false,
+      submissionId,
       progress: {
         status: progress.status,
         progressPercent: progress.progressPercent,
         completedChallenges: progress.completedChallenges,
         completedAt: progress.completedAt,
       },
-      stageCompleted: progress.status === "completed",
       stageCompleted: progress.status === "completed",
       xpReward: xpResult ? {
         xpAwarded: true,
@@ -518,6 +765,74 @@ exports.resetStageProgress = async (req, res) => {
     res.json({ message: "Stage progress reset" });
   } catch (err) {
     console.error(err);
+    res.status(500).json({ message: "Server error", detail: err.message });
+  }
+};
+
+/** Admin: generate exercises for a stage using AI */
+exports.generateStageExercises = async (req, res) => {
+  try {
+    if (req.user.role !== "admin") return res.status(403).json({ message: "Forbidden" });
+    const { id } = req.params;
+    const { count = 3, topic, difficulty = "easy", language = "javascript" } = req.body;
+
+    const stage = await Stage.findById(id);
+    if (!stage) return res.status(404).json({ message: "Stage not found" });
+
+    let generated = [];
+    let source = "ai";
+    let warning = null;
+    try {
+      generated = await generateChallenges({
+        topic: topic || stage.title,
+        difficulty,
+        language,
+        count: Number(count),
+      });
+    } catch (aiErr) {
+      generated = generateFallbackStageExercises({
+        topic: topic || stage.title,
+        difficulty,
+        language,
+        count: Number(count),
+      });
+      source = "fallback";
+      warning = aiErr.message || "AI generation failed; fallback drafts were generated.";
+    }
+
+    const created = [];
+    for (const g of generated) {
+      const ch = new Challenge({
+        title: g.title,
+        description: g.description || "",
+        difficulty: g.difficulty || difficulty,
+        type: "Stage",
+        stageId: stage._id,
+        language: g.language || language,
+        starterCode: g.starterCode || "",
+        testCases: Array.isArray(g.testCases) ? g.testCases : [],
+        category: g.category || "general",
+        constraints: g.constraints || "",
+        xpReward: g.xpReward || (difficulty === "easy" ? 50 : difficulty === "medium" ? 100 : 200),
+      });
+      await ch.save();
+      stage.challenges.push(ch._id);
+      created.push(ch);
+    }
+
+    await stage.save();
+    const populated = await Stage.findById(id).populate("challenges").populate("prerequisiteStageId", "title order");
+    res.status(201).json({ created, stage: populated, source, warning });
+  } catch (err) {
+    console.error(err);
+    if (err.code && String(err.code).startsWith("AI_")) {
+      return res.status(httpStatusForAiError(err)).json({
+        message: err.message,
+        code: err.code,
+        detail: err.detail || err.cause?.message,
+        helpUrl: err.helpUrl,
+      });
+    }
     res.status(500).json({ message: "Server error", detail: err.message });
   }
 };

--- a/Back/src/models/UserStageProgress.js
+++ b/Back/src/models/UserStageProgress.js
@@ -33,6 +33,18 @@ const userStageProgressSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+
+    failedAttemptsByChallenge: {
+      type: Map,
+      of: Number,
+      default: {},
+    },
+
+    lastCodeByChallenge: {
+      type: Map,
+      of: String,
+      default: {},
+    },
   },
   { timestamps: true }
 );

--- a/frontend/src/pages/frontOffice/pages/ChallengeEditor.jsx
+++ b/frontend/src/pages/frontOffice/pages/ChallengeEditor.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
 import Editor from "@monaco-editor/react";
-import { ArrowLeft, Loader2, Play, Send, CheckCircle2, XCircle } from "lucide-react";
+import { ArrowLeft, Loader2, Play, Send, CheckCircle2, XCircle, Lightbulb, BookOpen, HelpCircle, X } from "lucide-react";
 import Swal from "sweetalert2";
 import { stagesApi } from "../../../services/api";
 import { LevelUpModal } from "../components/Gamification/LevelUpModal";
@@ -15,6 +16,13 @@ export default function ChallengeEditor() {
   const [challenge, setChallenge] = useState(null);
   const [language, setLanguage] = useState("javascript");
   const [code, setCode] = useState("");
+
+  // Reset auto hint preview when code changes (edge case handling)
+  useEffect(() => {
+    if (autoHintPreview) {
+      setAutoHintPreview(null);
+    }
+  }, [code]);
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -22,6 +30,22 @@ export default function ChallengeEditor() {
   const [submitResult, setSubmitResult] = useState(null);
   const [showLevelUp, setShowLevelUp] = useState(false);
   const [newLevel, setNewLevel] = useState(1);
+
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [helpLoading, setHelpLoading] = useState(false);
+  const [helpError, setHelpError] = useState(null);
+  const [helpData, setHelpData] = useState(null);
+  const [helpCooldownUntil, setHelpCooldownUntil] = useState(0);
+  const [helpActiveType, setHelpActiveType] = useState(null);
+  const [autoHintPreview, setAutoHintPreview] = useState(null);
+
+  // Guard to prevent duplicate auto-hint triggers per submission response
+  const autoHintTriggeredRef = useRef(false);
+
+  // Reset guard when challengeId changes
+  useEffect(() => {
+    autoHintTriggeredRef.current = false;
+  }, [challengeId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -82,13 +106,138 @@ export default function ChallengeEditor() {
     }
   };
 
+  const requestHelp = async (type) => {
+    const now = Date.now();
+    if (helpLoading) return;
+    if (now < helpCooldownUntil) return;
+
+    const COSTS = { hint: 5, explain: 10, course: 15 };
+    const xpCost = COSTS[type] ?? COSTS.hint;
+
+    const confirm = await Swal.fire({
+      icon: "question",
+      title: "Use help?",
+      text: `This will cost ${xpCost} XP. Continue?`,
+      showCancelButton: true,
+      confirmButtonText: "Yes",
+      cancelButtonText: "Cancel",
+      background: "#1a1a2e",
+      color: "#fff",
+    });
+
+    if (!confirm.isConfirmed) return;
+
+    setHelpOpen(true);
+    setHelpLoading(true);
+    setHelpActiveType(type);
+    setHelpError(null);
+    setHelpData(null);
+
+    const cooldownTarget = now + 10_000;
+    setHelpCooldownUntil(cooldownTarget);
+
+    try {
+      const { data } = await stagesApi.help(stageId, challengeId, {
+        type,
+        code,
+      });
+      setHelpData(data?.help || null);
+
+      if (data?.xpCost) {
+        const remaining = data?.xp?.points;
+        const spent = data?.xpCost;
+        Swal.fire({
+          icon: "success",
+          title: "Help used",
+          text: remaining !== undefined ? `-${spent} XP (Remaining: ${remaining} XP)` : `-${spent} XP`,
+          background: "#1a1a2e",
+          color: "#fff",
+          timer: 2200,
+          showConfirmButton: false,
+        });
+      }
+    } catch (e) {
+      const body = e.response?.data;
+      if (body?.code === "INSUFFICIENT_XP") {
+        Swal.fire({
+          icon: "warning",
+          title: "Not enough XP",
+          text: `You need ${body.required} XP but you only have ${body.current} XP.`,
+          background: "#1a1a2e",
+          color: "#fff",
+        });
+        setHelpOpen(false);
+      } else {
+        setHelpError(body?.message || e.message);
+      }
+    } finally {
+      setHelpLoading(false);
+      setHelpActiveType(null);
+      const remainingMs = Math.max(0, cooldownTarget - Date.now());
+      if (remainingMs > 0) {
+        setTimeout(() => {
+          setHelpCooldownUntil((v) => (Date.now() >= v ? 0 : v));
+        }, remainingMs);
+      } else {
+        setHelpCooldownUntil(0);
+      }
+    }
+  };
+
+  const helpDisabled = helpLoading || Date.now() < helpCooldownUntil;
+
+  // Auto-fetch hint preview directly from API response (not via useEffect)
+  const fetchAutoHint = async () => {
+    console.log("fetchAutoHint called - checking guard");
+    
+    // Guard: only trigger once per submission response
+    if (autoHintTriggeredRef.current) {
+      console.log("AUTO HINT SKIPPED (already triggered for this submission)");
+      return;
+    }
+
+    autoHintTriggeredRef.current = true;
+    console.log("AUTO HINT TRIGGERED (once per submission) - calling API");
+
+    try {
+      const response = await stagesApi.help(stageId, challengeId, {
+        type: "hint",
+        code,
+      });
+      console.log("AUTO HINT API RESPONSE:", JSON.stringify(response.data, null, 2));
+      setAutoHintPreview(response.data?.help || null);
+      console.log("AUTO HINT FETCHED SUCCESSFULLY");
+    } catch (e) {
+      console.error("AUTO HINT FAILED:", e);
+      console.error("AUTO HINT FAILED DETAILS:", JSON.stringify(e.response?.data, null, 2));
+      // Silent fail for auto hint
+    }
+  };
+
+  const getStuckMessage = () => {
+    const fails = submitResult?.failedSubmissionsInRow || 0;
+    if (fails >= 6) return "This is a tough one. Try an explanation or mini course?";
+    if (fails >= 4) return "You're close! Want a hint to push you forward?";
+    if (fails >= 3) return "You've tried this challenge 3 times. Need a little help?";
+    return "Need help? It looks like you're stuck on this challenge.";
+  };
+
   const handleSubmit = async () => {
     setSubmitting(true);
     setSubmitResult(null);
     try {
-      const { data } = await stagesApi.submit(stageId, challengeId, code);
+      const response = await stagesApi.submit(stageId, challengeId, code);
+      const data = response.data;
+      console.log("SUBMIT RESPONSE FULL (SUCCESS):", JSON.stringify(data, null, 2));
+      console.log("STUCK LEVEL RECEIVED (SUCCESS):", data.stuckLevel, "autoHintTrigger:", data.autoHintTrigger);
       setSubmitResult(data);
-      
+
+      // Reset auto hint on success and reset guard
+      if (autoHintPreview) {
+        setAutoHintPreview(null);
+      }
+      autoHintTriggeredRef.current = false;
+
       const textMessage = data.stageCompleted
         ? `You've mastered this stage!${data.xpReward?.xpAmount ? ` You earned +${data.xpReward.xpAmount} XP!` : ''}`
         : data.nextStageUnlocked
@@ -110,17 +259,47 @@ export default function ChallengeEditor() {
         color: "#fff",
         timer: 3500,
         showConfirmButton: true,
+        confirmButtonText: data.stageCompleted ? "Return to map" : "Nice",
+      }).then(() => {
+        if (data.stageCompleted) {
+          navigate("/map");
+        }
       });
     } catch (e) {
       const body = e.response?.data;
+      console.log("SUBMIT RESPONSE FULL (ERROR):", JSON.stringify(body, null, 2));
+
+      // Support nested response structures
+      const autoHintTrigger = body?.autoHintTrigger ?? body?.data?.autoHintTrigger ?? body?.result?.autoHintTrigger ?? false;
+      const isStuck = body?.isStuck ?? body?.data?.isStuck ?? false;
+      const failedSubmissionsInRow = body?.failedSubmissionsInRow ?? body?.data?.failedSubmissionsInRow ?? 0;
+      const stuckLevel = body?.stuckLevel ?? body?.data?.stuckLevel ?? 0;
+
+      console.log("AUTO HINT CHECK - autoHintTrigger:", autoHintTrigger, "type:", typeof autoHintTrigger);
+      console.log("STUCK LEVEL RECEIVED:", stuckLevel, "isStuck:", isStuck, "fails:", failedSubmissionsInRow);
+
       setSubmitResult({
         error: true,
         message: body?.message || e.message,
-        testResults: body?.testResults,
-        executionTimeMs: body?.executionTimeMs,
-        sonar: body?.sonar,
-        aiFeedback: body?.aiFeedback,
+        testResults: body?.testResults ?? body?.data?.testResults,
+        executionTimeMs: body?.executionTimeMs ?? body?.data?.executionTimeMs,
+        sonar: body?.sonar ?? body?.data?.sonar,
+        aiFeedback: body?.aiFeedback ?? body?.data?.aiFeedback,
+        isStuck,
+        failedSubmissionsInRow,
+        stuckLevel,
+        autoHintTrigger,
+        isDuplicate: body?.isDuplicate,
+        isMeaningfulCode: body?.isMeaningfulCode,
       });
+
+      // Trigger auto hint ONLY if backend says so (server-driven)
+      if (autoHintTrigger === true && !helpLoading) {
+        console.log("AUTO HINT TRIGGERED - calling fetchAutoHint()");
+        fetchAutoHint();
+      } else {
+        console.log("AUTO HINT NOT TRIGGERED - autoHintTrigger:", autoHintTrigger, "helpLoading:", helpLoading);
+      }
     } finally {
       setSubmitting(false);
     }
@@ -187,6 +366,21 @@ export default function ChallengeEditor() {
           >
             {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
             Submit
+          </button>
+
+          <button
+            type="button"
+            onClick={() => requestHelp("hint")}
+            disabled={helpDisabled}
+            className="flex items-center gap-1 px-3 py-2 rounded-lg bg-purple-700/60 hover:bg-purple-700 text-xs font-bold uppercase disabled:opacity-50 disabled:hover:bg-purple-700/60"
+            title="Get a hint"
+          >
+            {helpLoading && helpActiveType === "hint" ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Lightbulb className="w-4 h-4" />
+            )}
+            Hint
           </button>
         </div>
       </header>
@@ -271,13 +465,120 @@ export default function ChallengeEditor() {
                 {submitResult.aiFeedback && (
                   <div className="rounded-lg border border-slate-800 p-3 bg-slate-900/60">
                     <p className="text-[10px] uppercase text-slate-500 mb-1">AI feedback</p>
-                    <p className="text-xs text-slate-400">{submitResult.aiFeedback.summary}</p>
-                    {(submitResult.aiFeedback.suggestions || []).map((s, i) => (
-                      <p key={i} className="text-xs text-slate-500 mt-1">
-                        • {s}
-                      </p>
-                    ))}
+                    {submitResult.aiFeedback.summary && (
+                      <p className="text-xs text-slate-400">{submitResult.aiFeedback.summary}</p>
+                    )}
+
+                    {Array.isArray(submitResult.aiFeedback.bugs) && submitResult.aiFeedback.bugs.length > 0 && (
+                      <div className="mt-2 rounded-md border border-rose-500/20 bg-rose-500/5 p-2">
+                        <p className="text-[10px] uppercase text-rose-400 font-bold mb-1">Bugs</p>
+                        {submitResult.aiFeedback.bugs.map((b, i) => (
+                          <p key={i} className="text-xs text-rose-200">
+                            • {b}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+
+                    {Array.isArray(submitResult.aiFeedback.suggestions) && submitResult.aiFeedback.suggestions.length > 0 && (
+                      <div className="mt-2 rounded-md border border-blue-500/20 bg-blue-500/5 p-2">
+                        <p className="text-[10px] uppercase text-blue-400 font-bold mb-1">Suggestions</p>
+                        {submitResult.aiFeedback.suggestions.map((s, i) => (
+                          <p key={i} className="text-xs text-slate-300">
+                            • {s}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+
+                    {Array.isArray(submitResult.aiFeedback.improvements) && submitResult.aiFeedback.improvements.length > 0 && (
+                      <div className="mt-2 rounded-md border border-amber-500/20 bg-amber-500/5 p-2">
+                        <p className="text-[10px] uppercase text-amber-300 font-bold mb-1">Improvements</p>
+                        {submitResult.aiFeedback.improvements.map((s, i) => (
+                          <p key={i} className="text-xs text-slate-300">
+                            • {s}
+                          </p>
+                        ))}
+                      </div>
+                    )}
                   </div>
+                )}
+
+                {submitResult.isStuck && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3 }}
+                    className="rounded-lg border border-purple-500/20 bg-purple-500/5 p-4"
+                  >
+                    <p className="text-sm font-semibold text-purple-200">
+                      {getStuckMessage()}
+                    </p>
+                    <p className="text-xs text-slate-400 mt-1">
+                      Failed submissions in a row: {submitResult.failedSubmissionsInRow || 0}
+                    </p>
+
+                    {/* Auto-fetched hint preview after 5 failures */}
+                    {autoHintPreview && (
+                      <div className="mt-3 rounded-md border border-purple-500/10 bg-purple-500/5 p-3">
+                        <p className="text-[10px] uppercase tracking-widest text-purple-400 font-bold mb-1">Auto hint preview</p>
+                        {autoHintPreview.content && (
+                          <p className="text-xs text-slate-300 leading-relaxed">{autoHintPreview.content}</p>
+                        )}
+                        {Array.isArray(autoHintPreview.keyPoints) && autoHintPreview.keyPoints.length > 0 && (
+                          <ul className="mt-2 space-y-1">
+                            {autoHintPreview.keyPoints.slice(0, 3).map((k, i) => (
+                              <li key={i} className="text-xs text-slate-400">
+                                • {k}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    )}
+
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => requestHelp("hint")}
+                        disabled={helpDisabled}
+                        className="inline-flex items-center gap-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 text-xs font-bold text-purple-200 hover:bg-purple-500/15 disabled:opacity-50"
+                      >
+                        {helpLoading && helpActiveType === "hint" ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <Lightbulb className="w-4 h-4" />
+                        )}
+                        Hint (-5 XP)
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => requestHelp("explain")}
+                        disabled={helpDisabled}
+                        className="inline-flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs font-bold text-blue-200 hover:bg-blue-500/15 disabled:opacity-50"
+                      >
+                        {helpLoading && helpActiveType === "explain" ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <BookOpen className="w-4 h-4" />
+                        )}
+                        Explanation (-10 XP)
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => requestHelp("course")}
+                        disabled={helpDisabled}
+                        className="inline-flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs font-bold text-amber-200 hover:bg-amber-500/15 disabled:opacity-50"
+                      >
+                        {helpLoading && helpActiveType === "course" ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <BookOpen className="w-4 h-4" />
+                        )}
+                        Mini Course (-15 XP)
+                      </button>
+                    </div>
+                  </motion.div>
                 )}
               </div>
             )}
@@ -297,8 +598,46 @@ export default function ChallengeEditor() {
                 {submitResult.sonar && (
                   <p className="text-xs text-slate-500">Quality score: {submitResult.sonar.qualityScore}</p>
                 )}
-                {submitResult.aiFeedback?.summary && (
-                  <p className="text-xs text-slate-500">{submitResult.aiFeedback.summary}</p>
+                {submitResult.aiFeedback && (
+                  <div className="rounded-lg border border-slate-800 p-3 bg-slate-900/60">
+                    <p className="text-[10px] uppercase text-slate-500 mb-1">AI feedback</p>
+                    {submitResult.aiFeedback.summary && (
+                      <p className="text-xs text-slate-400">{submitResult.aiFeedback.summary}</p>
+                    )}
+
+                    {Array.isArray(submitResult.aiFeedback.bugs) && submitResult.aiFeedback.bugs.length > 0 && (
+                      <div className="mt-2 rounded-md border border-rose-500/20 bg-rose-500/5 p-2">
+                        <p className="text-[10px] uppercase text-rose-400 font-bold mb-1">Bugs</p>
+                        {submitResult.aiFeedback.bugs.map((b, i) => (
+                          <p key={i} className="text-xs text-rose-200">
+                            • {b}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+
+                    {Array.isArray(submitResult.aiFeedback.suggestions) && submitResult.aiFeedback.suggestions.length > 0 && (
+                      <div className="mt-2 rounded-md border border-blue-500/20 bg-blue-500/5 p-2">
+                        <p className="text-[10px] uppercase text-blue-400 font-bold mb-1">Suggestions</p>
+                        {submitResult.aiFeedback.suggestions.map((s, i) => (
+                          <p key={i} className="text-xs text-slate-300">
+                            • {s}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+
+                    {Array.isArray(submitResult.aiFeedback.improvements) && submitResult.aiFeedback.improvements.length > 0 && (
+                      <div className="mt-2 rounded-md border border-amber-500/20 bg-amber-500/5 p-2">
+                        <p className="text-[10px] uppercase text-amber-300 font-bold mb-1">Improvements</p>
+                        {submitResult.aiFeedback.improvements.map((s, i) => (
+                          <p key={i} className="text-xs text-slate-300">
+                            • {s}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
             )}
@@ -315,6 +654,117 @@ export default function ChallengeEditor() {
         level={newLevel} 
         onClose={() => setShowLevelUp(false)} 
       />
+
+      {helpOpen && (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4">
+          <div className="w-full max-w-2xl rounded-2xl border border-slate-800 bg-slate-950 text-slate-200 shadow-2xl overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-slate-800 bg-slate-900/60">
+              <div className="flex items-center gap-2">
+                <HelpCircle className="w-4 h-4 text-purple-300" />
+                <h3 className="text-sm font-bold">Need help?</h3>
+              </div>
+              <button
+                type="button"
+                onClick={() => setHelpOpen(false)}
+                className="p-2 rounded-lg hover:bg-slate-800 text-slate-400"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            <div className="px-4 py-3 border-b border-slate-800 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => requestHelp("hint")}
+                disabled={helpDisabled}
+                className="inline-flex items-center gap-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 text-xs font-bold text-purple-200 hover:bg-purple-500/15 disabled:opacity-50 disabled:hover:bg-purple-500/10"
+              >
+                {helpLoading && helpActiveType === "hint" ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Lightbulb className="w-4 h-4" />
+                )}
+                Hint (-5 XP)
+              </button>
+              <button
+                type="button"
+                onClick={() => requestHelp("explain")}
+                disabled={helpDisabled}
+                className="inline-flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs font-bold text-blue-200 hover:bg-blue-500/15 disabled:opacity-50 disabled:hover:bg-blue-500/10"
+              >
+                {helpLoading && helpActiveType === "explain" ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <BookOpen className="w-4 h-4" />
+                )}
+                Explanation (-10 XP)
+              </button>
+              <button
+                type="button"
+                onClick={() => requestHelp("course")}
+                disabled={helpDisabled}
+                className="inline-flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs font-bold text-amber-200 hover:bg-amber-500/15 disabled:opacity-50 disabled:hover:bg-amber-500/10"
+              >
+                {helpLoading && helpActiveType === "course" ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <BookOpen className="w-4 h-4" />
+                )}
+                Mini Course (-15 XP)
+              </button>
+            </div>
+
+            <div className="p-4">
+              {helpLoading && (
+                <div className="flex items-center gap-2 text-slate-400 text-sm">
+                  <Loader2 className="w-4 h-4 animate-spin" /> Loading help...
+                </div>
+              )}
+
+              {helpError && !helpLoading && (
+                <div className="rounded-xl border border-rose-500/20 bg-rose-500/5 p-4 text-rose-200 text-sm">
+                  {helpError}
+                </div>
+              )}
+
+              {helpData && !helpLoading && (
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-widest text-slate-500 font-bold">{helpData.title || "Help"}</p>
+                    {helpData.content && <p className="mt-2 text-sm text-slate-300 leading-relaxed">{helpData.content}</p>}
+                  </div>
+
+                  {Array.isArray(helpData.keyPoints) && helpData.keyPoints.length > 0 && (
+                    <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-3">
+                      <p className="text-[10px] uppercase tracking-widest text-slate-500 font-bold mb-2">Key points</p>
+                      {helpData.keyPoints.map((k, i) => (
+                        <p key={i} className="text-xs text-slate-300">
+                          - {k}
+                        </p>
+                      ))}
+                    </div>
+                  )}
+
+                  {Array.isArray(helpData.resources) && helpData.resources.length > 0 && (
+                    <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-3">
+                      <p className="text-[10px] uppercase tracking-widest text-slate-500 font-bold mb-2">Resources</p>
+                      {helpData.resources.map((r, i) => (
+                        <p key={i} className="text-xs text-slate-400">
+                          - {r}
+                        </p>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {!helpData && !helpLoading && !helpError && (
+                <p className="text-slate-500 text-sm">Choose an option above to get help.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
…afety

- Backend: Add autoHintTrigger boolean flag computed by backend logic (stuckLevel >= 2)
- Backend: Add submissionId to all responses for unique tracking
- Backend: Add lastCodeByChallenge map to prevent duplicate submission counting
- Backend: Only increment failed counter for non-empty, non-duplicate code
- Frontend: Remove stuckLevel-based trigger, use server-driven autoHintTrigger
- Frontend: Add useRef guard to prevent duplicate auto-hint triggers per submission
- Frontend: Reset guard on challengeId change or success submission
- Frontend: Support nested response structures for autoHintTrigger
- Frontend: Add comprehensive logging for debugging auto-hint flow
- Frontend: Reset autoHintPreview on code change, success, new challenge